### PR TITLE
Bug Fix: migrations fail when using in memory database

### DIFF
--- a/server/migrations/env.py
+++ b/server/migrations/env.py
@@ -1,13 +1,12 @@
 from logging.config import fileConfig
-from os import getenv
 
-from sqlalchemy import engine_from_config
-from sqlalchemy import pool
+from sqlalchemy import create_engine
 
 from alembic import context
 
 from app.config import settings
-from app.database import engine
+
+# from app.database import engine
 from app.models import Base
 
 # this is the Alembic Config object, which provides
@@ -43,7 +42,6 @@ def run_migrations_offline() -> None:
     script output.
 
     """
-    # url = config.get_main_option("sqlalchemy.url")
     context.configure(
         url=settings.backup_database_uri,
         target_metadata=target_metadata,
@@ -63,6 +61,7 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
+    engine = create_engine(settings.backup_database_uri, future=True, echo=False)
     with engine.connect() as connection:
         context.configure(connection=connection, target_metadata=target_metadata)
 


### PR DESCRIPTION
Now that the live system is using an in-memory database with a file backup we cannot run migrations on the (in memory) database before starting the app (because the in-memory database will be destroyed before starting the app).

This commit fixes this issue by running migrations on the backup database before loading it into memory. This also fixes a migration that assumed the live database is a file and connected to the database that the application is aware of (the in-memory database).